### PR TITLE
Fix typo in Windows installer as it cause error in python3 install. M…

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -27,7 +27,7 @@ def check_prv():
                          'reset'))
 
 
-def linux_osx():
+def linux():
     check_prv()
     executor = '''#!/bin/bash\npython /usr/share/owasp_zsc/zsc.py "$@"'''
     print(color.color('cyan') + 'Building Commandline')
@@ -42,6 +42,20 @@ def linux_osx():
         '\nNow you can remove this folder\nfiles copied in /usr/share/owasp_zsc.\nto run zcr shellcoder please use "zsc" command line\n'
         + color.color('reset'))
 
+def osx():
+    check_prv()
+    executor = '''#!/bin/bash\npython /usr/local/share/owasp_zsc/zsc.py "$@"'''
+    print(color.color('cyan') + 'Building Commandline')
+    commandline = open('/usr/local/bin/zsc', 'w')
+    commandline.write(executor)
+    commandline.close()
+    print(color.color('green') + 'Copying Files' + color.color('white'))
+    os.system(
+        'rm -rf /usr/local/share/owasp_zsc && mkdir /usr/local/share/owasp_zsc && cp -r * /usr/local/share/owasp_zsc/ && chmod +x /usr/local/share/owasp_zsc/zsc.py && chmod +x /usr/local/bin/zsc')
+    print(
+        color.color('yellow') +
+        '\nNow you can remove this folder\nfiles copied in /usr/local/share/owasp_zsc.\nto run zcr shellcoder please use "zsc" command line\n'
+        + color.color('reset'))
 
 def windows():
     #check_prv()
@@ -59,13 +73,16 @@ def windows():
     tmp_add_command_line.close()
     print(
         color.color('yellow') +
-        '\nNow you can remove this folder\nfiles copied in %s.\nto run zcr shellcoder please use "zsc" command line\nNOTE: IF COMMAND LINE "zsc" NOT FOUND, PLEASE RE-OPEN YOUR CMD!\N'
+        '\nNow you can remove this folder\nfiles copied in %s.\nto run zcr shellcoder please use "zsc" command line\nNOTE: IF COMMAND LINE "zsc" NOT FOUND, PLEASE RE-OPEN YOUR CMD!\n'
         % installing_path + color.color('reset'))
 
 
-if 'linux' in sys.platform or 'darwin' in sys.platform:
+if 'linux' in sys.platform:
     os.system('clear')
-    linux_osx()
+    linux()
+elif 'darwin' in sys.platform:
+    os.system('clear')
+    osx()
 elif 'win32' in sys.platform or 'win64' in sys.platform:
     os.system('cls')
     windows()

--- a/uninstaller.py
+++ b/uninstaller.py
@@ -11,13 +11,21 @@ import sys
 from core import start
 from core import color
 #start.logo()
-if 'linux' in sys.platform or 'darwin' in sys.platform:
+if 'linux' in sys.platform:
     if os.geteuid() is not 0:
         sys.exit(color.color('red') + 'Sorry, you most run this file as root.'
                  + color.color('reset'))
     os.system('clear')
     print(color.color('green') + 'Removing Files' + color.color('white'))
     os.system('rm -rf /usr/share/owasp_zsc /usr/bin/zsc')
+    print(color.color('green') + 'Files Removed!' + color.color('white'))
+elif 'darwin' in sys.platform:
+    if os.geteuid() is not 0:
+        sys.exit(color.color('red') + 'Sorry, you most run this file as root.'
+                 + color.color('reset'))
+    os.system('clear')
+    print(color.color('green') + 'Removing Files' + color.color('white'))
+    os.system('rm -rf /usr/local/share/owasp_zsc /usr/local/bin/zsc')
     print(color.color('green') + 'Files Removed!' + color.color('white'))
 elif 'win32' in sys.platform or 'win64' in sys.platform:
     #import ctypes


### PR DESCRIPTION
move the installation folder from /usr/share -> /usr/local/share because of the rootless features in el capitan

Fix typo in the windows installation.