### PR TITLE
fix typo (plathform --> platform)

### DIFF
--- a/lib/shell_storm_api/grab.py
+++ b/lib/shell_storm_api/grab.py
@@ -44,7 +44,7 @@ def _search_shellcode(cli,keyword):
 	for shellcode_ in data.rsplit('\n'):
 		try:
 			shellcode_ = shellcode_.rsplit('::::')
-			info('author: %s\tshellcode_id: %s\tplathform: %s\ttitle: %s\n' %
+			info('author: %s\tshellcode_id: %s\tplatform: %s\ttitle: %s\n' %
 				 (shellcode_[0], shellcode_[3], shellcode_[1], shellcode_[2]))
 		except:
 			pass


### PR DESCRIPTION
This fixes the typo in `grab.py` which occurs when using shellcode/search.